### PR TITLE
Ignore Vite cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary
- add the .vite build cache to .gitignore to keep the repo clean

## Testing
- not applicable
