### PR TITLE
Polish homepage messaging and Studio visuals

### DIFF
--- a/src/components/GlyphIcon.vue
+++ b/src/components/GlyphIcon.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+const props = defineProps<{ name: string }>()
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    class="h-10 w-10 text-brand-blue"
+    aria-hidden="true"
+  >
+    <template v-if="props.name === 'dashboard'">
+      <rect x="3" y="4" width="18" height="7" rx="2" ry="2" />
+      <rect x="3" y="14" width="8" height="6" rx="2" ry="2" />
+      <rect x="13" y="14" width="8" height="6" rx="2" ry="2" />
+    </template>
+    <template v-else-if="props.name === 'desk'">
+      <path d="M4 7a3 3 0 013-3h10a3 3 0 013 3v3H4V7z" />
+      <path d="M4 10h16v9a1 1 0 01-1 1h-4v-4H9v4H5a1 1 0 01-1-1v-9z" />
+      <path d="M10 6h4" />
+    </template>
+    <template v-else-if="props.name === 'sensors'">
+      <path d="M12 5v14" />
+      <path d="M6.5 8.5a6 6 0 0111 0" />
+      <path d="M5 12a7 7 0 0114 0" />
+      <circle cx="12" cy="16" r="2.5" />
+    </template>
+    <template v-else-if="props.name === 'family'">
+      <circle cx="8.5" cy="9" r="2.3" />
+      <circle cx="15.5" cy="9" r="2.3" />
+      <path d="M4.5 19c1.3-3 3.9-5 7.5-5s6.2 2 7.5 5" />
+    </template>
+    <template v-else-if="props.name === 'roadmap'">
+      <path d="M4 6l6-2 4 2 6-2v14l-6 2-4-2-6 2V6z" />
+      <path d="M10 4v14" />
+      <path d="M14 6v14" />
+    </template>
+    <template v-else-if="props.name === 'guide'">
+      <path d="M6 4.5A1.5 1.5 0 017.5 3h8A1.5 1.5 0 0117 4.5v15l-5-2-5 2v-15z" />
+      <path d="M9 7h6" />
+      <path d="M9 10h6" />
+    </template>
+    <template v-else-if="props.name === 'labs'">
+      <path d="M8 4h8" />
+      <path d="M10 4v5l-4.5 7.5A2 2 0 007.2 20h9.6a2 2 0 001.7-3.5L14 9V4" />
+      <path d="M9 16h6" />
+    </template>
+    <template v-else-if="props.name === 'partners'">
+      <circle cx="7.5" cy="8" r="3" />
+      <circle cx="16.5" cy="8" r="3" />
+      <path d="M3 20c0-3 2.5-6 4.5-6s4.5 3 4.5 6" />
+      <path d="M12 20c0-3 2.5-6 4.5-6S21 17 21 20" />
+    </template>
+    <template v-else>
+      <circle cx="12" cy="12" r="8" />
+      <path d="M8 12h8" />
+    </template>
+  </svg>
+</template>

--- a/src/components/MeshDiagram.vue
+++ b/src/components/MeshDiagram.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+const nodes = [
+  {
+    title: 'Sense on the edge',
+    subtitle: 'Lightweight capture + skills',
+    icon: 'edge',
+    bullets: ['Pi, ESP32, phones publishing events', 'Whisper Tiny streaming ASR', 'Local automations + sensors']
+  },
+  {
+    title: 'Coordinate in the core',
+    subtitle: 'Loqa runtime + planners',
+    icon: 'core',
+    bullets: ['NATS mesh + skill host', 'Planner LLM and tool chain', 'Observability: Grafana, Loki, Tempo']
+  },
+  {
+    title: 'Enrich with Studio',
+    subtitle: 'Optional, encrypted value-adds',
+    icon: 'studio',
+    bullets: ['Loqa Cloud zero-trust sync', 'Curated persona + skill packs', 'Shared dashboards & support']
+  }
+]
+</script>
+
+<template>
+  <div class="mt-12 space-y-8">
+    <div
+      v-for="(node, index) in nodes"
+      :key="node.title"
+      class="relative rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/15 md:flex md:items-start md:gap-6"
+    >
+      <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-blue/15 text-brand-blue md:h-14 md:w-14">
+        <svg
+          v-if="node.icon === 'edge'"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          class="h-7 w-7"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M7 7h10v5H7z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 16h16" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 19h12" />
+          <circle cx="8" cy="4" r="1.5" />
+          <circle cx="16" cy="4" r="1.5" />
+        </svg>
+        <svg
+          v-else-if="node.icon === 'core'"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          class="h-7 w-7"
+        >
+          <rect x="4" y="5" width="16" height="14" rx="2" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 9h8M8 13h5" />
+          <circle cx="17" cy="13" r="1.5" />
+        </svg>
+        <svg
+          v-else
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          class="h-7 w-7"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 9l7-5 7 5v9a2 2 0 01-2 2H7a2 2 0 01-2-2z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 17V9l3-2 3 2v8" />
+        </svg>
+      </div>
+      <div class="mt-4 flex-1 md:mt-0">
+        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-brand-blue">{{ (index + 1).toString().padStart(2, '0') }}</span>
+        <h3 class="mt-2 font-display text-xl text-white">{{ node.title }}</h3>
+        <p class="mt-1 text-sm font-medium text-white/60">{{ node.subtitle }}</p>
+        <ul class="mt-4 space-y-2 text-sm text-white/70">
+          <li v-for="item in node.bullets" :key="item" class="flex items-start gap-2">
+            <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+            <span>{{ item }}</span>
+          </li>
+        </ul>
+      </div>
+      <svg
+        v-if="index < nodes.length - 1"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        class="absolute -bottom-8 left-1/2 h-8 w-8 -translate-x-1/2 rotate-90 text-brand-blue/40 md:-right-9 md:bottom-1/2 md:h-10 md:w-10 md:translate-y-1/2 md:rotate-0"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-4-4m4 4l-4 4" />
+      </svg>
+    </div>
+  </div>
+</template>

--- a/src/components/PipelineDiagram.vue
+++ b/src/components/PipelineDiagram.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const stages = [
+  {
+    label: 'Sense',
+    description: 'Edge microphones, sensors, and apps publish events over NATS streams.'
+  },
+  {
+    label: 'Reason',
+    description: 'Local Whisper + planners interpret intent, with deterministic skills first and LLMs on fallback.'
+  },
+  {
+    label: 'Act',
+    description: 'Responses fan out to speakers, displays, or automations with audited permissions.'
+  }
+]
+</script>
+
+<template>
+  <div class="mt-12 flex flex-col items-stretch gap-6 md:flex-row md:items-center md:justify-between">
+    <div
+      v-for="(stage, index) in stages"
+      :key="stage.label"
+      class="relative flex-1 rounded-2xl border border-white/10 bg-white/5 p-6 shadow shadow-black/20"
+    >
+      <div class="text-sm font-semibold uppercase tracking-[0.35em] text-brand-blue">{{ stage.label }}</div>
+      <p class="mt-3 text-sm text-white/70">{{ stage.description }}</p>
+      <svg
+        v-if="index < stages.length - 1"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        class="hidden md:block absolute top-1/2 right-[-38px] h-10 w-10 -translate-y-1/2 text-brand-blue"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-4-4m4 4l-4 4" />
+      </svg>
+    </div>
+  </div>
+</template>

--- a/src/components/StudioFlowDiagram.vue
+++ b/src/components/StudioFlowDiagram.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="mt-8 flex flex-col items-center gap-6 rounded-3xl border border-white/10 bg-brand-dark/40 p-6 text-sm text-white/70 shadow shadow-black/20 md:flex-row md:items-stretch md:gap-8">
+    <div class="flex-1 space-y-2">
+      <div class="flex items-center gap-3">
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-brand-blue/15 text-brand-blue">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+            <rect x="3" y="4" width="18" height="14" rx="2" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7 9h10M7 13h6" />
+          </svg>
+        </span>
+        <div>
+          <h4 class="font-display text-lg text-white">Local runtime</h4>
+          <p class="text-xs text-white/60">MIT-licensed core, runs entirely on your LAN.</p>
+        </div>
+      </div>
+      <ul class="space-y-2 text-xs text-white/70">
+        <li class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>Skills execute as WASM modules; telemetry stays local.</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>NATS mesh connects edge microphones, planners, and automations.</span>
+        </li>
+      </ul>
+    </div>
+
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none" stroke="#00BCD4" stroke-width="1.5" class="h-10 w-10 text-brand-blue">
+      <path d="M10 20h20" />
+      <path d="M23 15l7 5-7 5" fill="#00BCD4" />
+    </svg>
+
+    <div class="flex-1 space-y-2">
+      <div class="flex items-center gap-3">
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-brand-blue/15 text-brand-blue">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 9.75h15M4.5 12.75h9" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 21l3-3H9l3 3z" />
+          </svg>
+        </span>
+        <div>
+          <h4 class="font-display text-lg text-white">Loqa Studio (opt-in)</h4>
+          <p class="text-xs text-white/60">Persona packs, cloud sync, and support plug in as needed.</p>
+        </div>
+      </div>
+      <ul class="space-y-2 text-xs text-white/70">
+        <li class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>Encrypted sync replicates only the data you allow.</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>Persona/TTS bundles drop in as modular assets; nothing changes if you stay offline.</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/components/StudioModelDiagram.vue
+++ b/src/components/StudioModelDiagram.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+const tiers = [
+  {
+    title: 'MIT Runtime',
+    subtitle: 'Free forever',
+    bullets: [
+      'Local-first services and tooling',
+      'Skills runtime + developer SDKs',
+      'Self-host without restrictions'
+    ]
+  },
+  {
+    title: 'Studio Add-ons',
+    subtitle: 'Optional enrichments',
+    bullets: [
+      'Curated persona packs',
+      'Premium skills & automations',
+      'Courses and pre-flashed hardware'
+    ]
+  },
+  {
+    title: 'Loqa Cloud',
+    subtitle: 'Opt-in collaboration',
+    bullets: [
+      'Zero-trust encrypted sync',
+      'Shared dashboards & presence',
+      'Support SLAs for teams'
+    ]
+  }
+]
+</script>
+
+<template>
+  <div class="mt-10 grid gap-6 md:grid-cols-3">
+    <div
+      v-for="(tier, index) in tiers"
+      :key="tier.title"
+      class="relative flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 shadow shadow-black/20"
+    >
+      <span class="text-xs font-semibold uppercase tracking-[0.3em] text-brand-blue">{{ (index + 1).toString().padStart(2, '0') }}</span>
+      <h3 class="mt-3 font-display text-2xl text-white">{{ tier.title }}</h3>
+      <p class="mt-2 text-sm font-medium text-white/60">{{ tier.subtitle }}</p>
+      <ul class="mt-4 space-y-2 text-sm text-white/70">
+        <li v-for="item in tier.bullets" :key="item" class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>{{ item }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/components/StudioPackCard.vue
+++ b/src/components/StudioPackCard.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+interface PersonaPack {
+  name: string
+  description: string
+  personas: string[]
+  highlights: string[]
+}
+
+const props = defineProps<{ pack: PersonaPack }>()
+</script>
+
+<template>
+  <div class="space-y-4 rounded-2xl border border-white/10 bg-white/10 p-6 shadow shadow-black/20">
+    <div>
+      <span class="rounded-full border border-brand-blue/40 bg-brand-blue/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.25em] text-brand-blue">
+        Sample pack
+      </span>
+      <h4 class="mt-3 font-display text-xl text-white">{{ props.pack.name }}</h4>
+      <p class="mt-2 text-sm text-white/70">{{ props.pack.description }}</p>
+    </div>
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/40">Personas</p>
+      <ul class="mt-2 flex flex-wrap gap-2 text-sm text-white/80">
+        <li v-for="persona in props.pack.personas" :key="persona" class="rounded-full border border-white/10 bg-white/5 px-3 py-1">
+          {{ persona }}
+        </li>
+      </ul>
+    </div>
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/40">Highlights</p>
+      <ul class="mt-2 space-y-2 text-sm text-white/70">
+        <li v-for="item in props.pack.highlights" :key="item" class="flex items-start gap-2">
+          <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+          <span>{{ item }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/components/layout/SiteFooter.vue
+++ b/src/components/layout/SiteFooter.vue
@@ -4,17 +4,17 @@
       <div>
         <h2 class="font-display text-2xl text-white">Loqa</h2>
         <p class="mt-2 max-w-md text-sm text-white/60">
-          Local-first ambient intelligence, built by Ambiware Labs. Privacy as a feature, not a trade-off.
+          Local-first ambient intelligence. Built in the open and stewarded by Ambiware Labs.
         </p>
       </div>
       <div class="flex flex-col gap-2 text-sm text-white/60">
         <a href="https://github.com/ambiware-labs" target="_blank" rel="noopener" class="hover:text-white">GitHub</a>
         <a href="mailto:hello@ambiware.ai" class="hover:text-white">hello@ambiware.ai</a>
-        <a href="https://ambiware.ai" target="_blank" rel="noopener" class="hover:text-white">ambiware.ai</a>
+        <span class="text-white/40">Loqa is an Ambiware Labs project.</span>
       </div>
     </div>
     <div class="border-t border-white/10 py-4 text-center text-xs text-white/40">
-      &copy; {{ new Date().getFullYear() }} Ambiware Labs. All rights reserved.
+      &copy; {{ new Date().getFullYear() }} Loqa · Ambiware Labs.
     </div>
   </footer>
 </template>

--- a/src/components/layout/SiteHeader.vue
+++ b/src/components/layout/SiteHeader.vue
@@ -3,15 +3,62 @@ import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import WaveLogo from '../WaveLogo.vue'
 
+type LinkTarget = {
+  name: string
+  to?: string | { path: string; hash?: string }
+  href?: string
+  external?: boolean
+}
+
+type NavGroup = {
+  name: string
+  items: LinkTarget[]
+}
+
 const isMenuOpen = ref(false)
 const route = useRoute()
 
-const links = [
-  { name: 'Home', to: '/' },
-  { name: 'Docs', to: '/docs' },
-  { name: 'Getting Started', to: '/getting-started' },
-  { name: 'Blog', to: '/blog' }
+const primaryCta: LinkTarget = { name: 'Try Loqa Alpha', to: '/getting-started' }
+
+const navMenuSections: NavGroup[] = [
+  {
+    name: 'Get started',
+    items: [
+      { name: 'Quickstart on GitHub', href: 'https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md', external: true },
+      { name: 'Runtime README', href: 'https://github.com/ambiware-labs/loqa-core', external: true },
+      { name: 'Extension Labs', href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md', external: true },
+      { name: 'Loqa core discussions', href: 'https://github.com/ambiware-labs/loqa-core/discussions', external: true }
+    ]
+  },
+  {
+    name: 'Learn',
+    items: [
+      { name: 'Ambient intelligence', to: { path: '/', hash: '#ambient-intelligence' } },
+      { name: 'How Loqa works', to: { path: '/', hash: '#how-it-works' } },
+      { name: 'Composable Open Core', to: { path: '/', hash: '#open-core' } },
+      { name: 'Why Loqa', to: { path: '/', hash: '#why-loqa' } }
+    ]
+  },
+  {
+    name: 'Community',
+    items: [
+      { name: 'Roadmap', href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md', external: true },
+      { name: 'Governance', href: 'https://github.com/ambiware-labs/loqa-meta/tree/main/governance', external: true },
+      { name: 'Blog', to: '/blog' },
+      { name: 'Docs hub', to: '/docs' }
+    ]
+  }
 ]
+
+const isActive = (target: LinkTarget) => {
+  if (target.to && typeof target.to === 'string') {
+    return route.path === target.to
+  }
+  if (target.to && typeof target.to === 'object') {
+    return route.path === target.to.path && (!target.to.hash || route.hash === target.to.hash)
+  }
+  return false
+}
 
 const toggleMenu = () => {
   isMenuOpen.value = !isMenuOpen.value
@@ -23,34 +70,78 @@ const closeMenu = () => {
 </script>
 
 <template>
-  <header class="sticky top-0 z-50 backdrop-blur bg-brand-dark/80 border-b border-white/5">
-    <nav class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-white/10 backdrop-blur-lg shadow-lg shadow-black/10">
+    <nav class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 md:px-10">
       <RouterLink to="/" class="inline-flex items-center gap-3" @click="closeMenu">
-        <WaveLogo />
+        <WaveLogo class="h-9 w-auto" />
       </RouterLink>
 
-      <div class="hidden items-center gap-6 md:flex">
+      <div class="hidden items-center gap-8 md:flex">
         <RouterLink
-          v-for="link in links"
-          :key="link.to"
-          :to="link.to"
-          class="text-sm font-medium text-white/80 transition-colors hover:text-white"
-          :class="{ 'text-brand-blue': route.path.startsWith(link.to) && link.to !== '/' || route.path === link.to }"
+          v-if="primaryCta.to"
+          :to="primaryCta.to"
+          class="cta-button px-6 py-2 text-sm"
         >
-          {{ link.name }}
+          {{ primaryCta.name }}
         </RouterLink>
-        <a
-          href="https://github.com/ambiware-labs/loqa-core"
-          target="_blank"
-          rel="noopener"
-          class="cta-button"
-        >
-          View on GitHub
-        </a>
+        <div class="relative group">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white/70 transition-colors hover:border-brand-blue/60 hover:text-white focus:outline-none"
+          >
+            Menu
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-white/50 group-hover:text-white">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 111.06 1.061l-4.24 4.24a.75.75 0 01-1.06 0l-4.24-4.24a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div
+            class="invisible absolute right-0 top-full mt-3 w-[320px] rounded-3xl border border-white/10 bg-brand-dark/95 p-5 opacity-0 shadow-2xl shadow-black/30 backdrop-blur group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition"
+          >
+            <div class="space-y-4">
+              <div v-for="section in navMenuSections" :key="section.name" class="space-y-2">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.35em] text-white/40">{{ section.name }}</p>
+                <ul class="space-y-1.5">
+                  <li v-for="item in section.items" :key="item.name">
+                    <RouterLink
+                      v-if="item.to"
+                      :to="item.to as any"
+                      class="flex items-center justify-between rounded-xl px-3 py-2 text-sm text-white/80 transition hover:bg-white/10 hover:text-white"
+                      :class="{ 'bg-white/10 text-white': isActive(item) }"
+                    >
+                      {{ item.name }}
+                      <span v-if="typeof item.to !== 'string' && item.to?.hash" class="text-white/40">#</span>
+                    </RouterLink>
+                    <a
+                      v-else
+                      :href="item.href"
+                      :target="item.external ? '_blank' : undefined"
+                      rel="noopener"
+                      class="flex items-center justify-between rounded-xl px-3 py-2 text-sm text-white/80 transition hover:bg-white/10 hover:text-white"
+                    >
+                      {{ item.name }}
+                      <svg
+                        v-if="item.external"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        class="h-4 w-4 text-white/50"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H18a2 2 0 012 2v10a2 2 0 01-2 2H8a2 2 0 01-2-2v-4.5" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 9l-9 9M11 9h4V5" />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <button
-        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-white md:hidden"
+        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 text-white md:hidden"
         @click="toggleMenu"
         aria-label="Toggle navigation"
       >
@@ -82,25 +173,40 @@ const closeMenu = () => {
 
     <transition name="fade">
       <div v-if="isMenuOpen" class="border-t border-white/10 bg-brand-dark/95 md:hidden">
-        <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6">
+        <div class="mx-auto flex max-w-6xl flex-col gap-5 px-6 py-6">
           <RouterLink
-            v-for="link in links"
-            :key="link.to"
-            :to="link.to"
-            class="text-base font-medium text-white/80"
-            :class="{ 'text-brand-blue': route.path.startsWith(link.to) && link.to !== '/' || route.path === link.to }"
+            v-if="primaryCta.to"
+            :to="primaryCta.to"
+            class="cta-button justify-center"
             @click="closeMenu"
           >
-            {{ link.name }}
+            {{ primaryCta.name }}
           </RouterLink>
-          <a
-            href="https://github.com/ambiware-labs/loqa-core"
-            target="_blank"
-            rel="noopener"
-            class="cta-button"
-          >
-            View on GitHub
-          </a>
+          <div v-for="section in navMenuSections" :key="section.name" class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/40">{{ section.name }}</p>
+            <div class="flex flex-col gap-2">
+              <template v-for="item in section.items" :key="item.name">
+                <RouterLink
+                  v-if="item.to"
+                  :to="item.to as any"
+                  class="rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80"
+                  @click="closeMenu"
+                >
+                  {{ item.name }}
+                </RouterLink>
+                <a
+                  v-else
+                  :href="item.href"
+                  :target="item.external ? '_blank' : undefined"
+                  rel="noopener"
+                  class="rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80"
+                  @click="closeMenu"
+                >
+                  {{ item.name }}
+                </a>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
     </transition>

--- a/src/style.css
+++ b/src/style.css
@@ -25,10 +25,10 @@
 
 @layer components {
   .cta-button {
-    @apply inline-flex items-center gap-2 rounded-full bg-brand-blue px-6 py-3 text-brand-dark font-semibold shadow-glow transition-transform hover:-translate-y-0.5 hover:shadow-xl;
+    @apply inline-flex items-center gap-2 rounded-full bg-brand-blue px-7 py-3 text-base font-semibold text-brand-dark shadow-glow transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-gold/90 hover:text-brand-dark;
   }
 
   .cta-button.secondary {
-    @apply bg-transparent border border-white/30 text-white hover:bg-white/10;
+    @apply bg-white/10 border border-white/20 text-white backdrop-blur hover:bg-white/20;
   }
 }

--- a/src/views/GettingStartedView.vue
+++ b/src/views/GettingStartedView.vue
@@ -59,7 +59,7 @@ const steps: Step[] = [
       The full Quickstart lives in the runtime repository, but here&apos;s the short version. Most developers have the pipeline running in under fifteen minutes.
     </p>
 
-    <ol class="mt-10 space-y-6">
+    <ol id="workflows" class="mt-10 space-y-6">
       <li
         v-for="(step, index) in steps"
         :key="step.title"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,4 +1,12 @@
 <script setup lang="ts">
+import GlyphIcon from '../components/GlyphIcon.vue'
+import PipelineDiagram from '../components/PipelineDiagram.vue'
+import MeshDiagram from '../components/MeshDiagram.vue'
+import StudioModelDiagram from '../components/StudioModelDiagram.vue'
+import StudioFlowDiagram from '../components/StudioFlowDiagram.vue'
+import StudioPackCard from '../components/StudioPackCard.vue'
+import CommandSnippet from '../components/CommandSnippet.vue'
+
 const pillars = [
   {
     title: 'Composable Open Core',
@@ -12,7 +20,7 @@ const pillars = [
   },
   {
     title: 'Loqa Studio add-ons',
-    description: 'Optional Studio bundles, encrypted Loqa Cloud, and support keep Loqa sustainable without locking anything down.',
+    description: 'Optional Studio persona packs, encrypted Loqa Cloud sync, and support plans keep Loqa sustainable without locking anything down.',
     href: 'https://github.com/ambiware-labs/loqa-meta/issues/25'
   }
 ]
@@ -28,7 +36,7 @@ const howItWorks = [
   },
   {
     title: 'Act & respond',
-    description: 'Loqa routes responses to ambient speakers, displays, and automations with strict permission boundaries.'
+    description: 'Loqa routes responses to ambient speakers, displays, and automations with auditable sandboxes and explicit permissions.'
   }
 ]
 
@@ -36,6 +44,10 @@ const features = [
   {
     title: 'Local-first by design',
     description: 'Every inference happens on hardware you own: Macs, minis, Pis, Jetsons. No silent cloud fallbacks.'
+  },
+  {
+    title: 'Privacy as a feature, not a tradeoff',
+    description: 'Ambient intelligence should work for you. Loqa refuses telemetry, dark patterns, and hidden data shares—agency stays in your hands.'
   },
   {
     title: 'Modular architecture',
@@ -54,19 +66,23 @@ const features = [
 const useCases = [
   {
     title: 'Ambient dashboard',
-    description: 'Morning briefings on an e-ink panel, calendar readouts, and contextual alerts without cloud dependence.'
+    description: 'Morning briefings on an e-ink panel, calendar readouts, and contextual alerts without cloud dependence.',
+    icon: 'dashboard'
   },
   {
     title: 'Desk co-pilot',
-    description: 'Hands-free timers, note capture, and notification triage while keeping data on your workstation.'
+    description: 'Hands-free timers, note capture, and notification triage while keeping data on your workstation.',
+    icon: 'desk'
   },
   {
     title: 'Sensor automations',
-    description: 'Skills react to motion, light, or air-quality sensors to orchestrate lighting, HVAC, or reminders locally.'
+    description: 'Skills react to motion, light, or air-quality sensors to orchestrate lighting, HVAC, or reminders locally.',
+    icon: 'sensors'
   },
   {
     title: 'Family companion',
-    description: 'Kid-friendly personas answer questions and play media with household rules you control.'
+    description: 'Kid-friendly personas answer questions and play media with household rules you control.',
+    icon: 'family'
   }
 ]
 
@@ -113,69 +129,94 @@ const communityLinks = [
   {
     title: 'Read the roadmap',
     description: 'Track Workstream progress and MVP milestones.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md'
+    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md',
+    icon: 'roadmap'
   },
   {
     title: 'Contributor guide',
     description: 'Find starter issues, publish skills, or propose an RFC.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/contributing-guide.md'
+    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/contributing-guide.md',
+    icon: 'guide'
   },
   {
     title: 'Extension Labs',
     description: 'Templates and checklists for building Loqa skills.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md'
+    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md',
+    icon: 'labs'
   },
   {
     title: 'Partner outreach',
     description: 'Collaborate on hardware kits, courses, or co-marketing.',
-    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/outreach/partner_pipeline.md'
+    href: 'https://github.com/ambiware-labs/loqa-meta/blob/main/community/outreach/partner_pipeline.md',
+    icon: 'partners'
   }
 ]
+
+const samplePack = {
+  name: 'Harbor Home Companion',
+  description: 'A bilingual household pack tuned for ambient reminders, bedtime audio, and privacy-safe kid requests.',
+  personas: ['Lighthouse Guide', 'Tea Timer', 'Study Buddy'],
+  highlights: [
+    'Localized prompts for English + Spanish households with quiet-hours awareness.',
+    'Ships with Kokoro voices, bedtime soundscapes, and household automations pre-curated for offline playback.',
+    'Bundle QA includes fairness, safety, and latency checklists ready for your own commercial packs.'
+  ]
+}
 </script>
 
 <template>
   <section>
     <div class="relative overflow-hidden">
-      <div class="absolute inset-0 bg-brand-gradient opacity-60 blur-3xl"></div>
+      <div class="absolute inset-0 bg-brand-gradient opacity-70 blur-3xl"></div>
+      <div class="absolute -top-40 -right-20 h-80 w-80 rounded-full bg-brand-blue/20 blur-3xl"></div>
       <div class="relative mx-auto flex max-w-6xl flex-col gap-12 px-6 py-20 md:py-24">
         <div class="max-w-3xl">
-          <span class="inline-flex flex-wrap items-center justify-center gap-1 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/70 sm:px-4 sm:text-sm sm:tracking-[0.3em]">
-            <span>Composable Open Core</span>
+          <span class="inline-flex flex-wrap items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1.5 text-xs uppercase tracking-[0.25em] text-white/70 sm:text-sm sm:tracking-[0.35em]">
+            <span title="MIT runtime + optional Studio add-ons—no gated core features">Composable Open Core</span>
             <span class="hidden sm:inline">•</span>
             <span>Modular</span>
             <span class="hidden sm:inline">•</span>
             <span>Ethical by design</span>
           </span>
-          <h1 class="mt-6 font-display text-5xl leading-tight text-white md:text-6xl">
-            Loqa keeps your AI assistant close to home.
+          <h1 class="mt-6 font-display text-4xl leading-tight text-white md:text-6xl">
+            Keep your AI assistant close to home.
           </h1>
-          <p class="mt-5 max-w-2xl text-lg text-white/70 md:text-xl">
-            A local-first, open-core platform for voice assistants and ambient interfaces. We steward a public-good runtime,
-            invite modular extensions, and offer optional value-add services—because privacy shouldn’t cost you flexibility.
+          <p class="mt-4 text-xl text-brand-blue/80 md:text-2xl">
+            Ambient intelligence that lives on your hardware, not someone else’s.
+          </p>
+          <p class="mt-4 max-w-2xl text-base text-white/70 md:text-lg">
+            Build and adapt your own ambient assistant. Loqa runs locally, stays modular, and invites you to add skills or personas whenever you need them.
           </p>
           <div class="mt-8 flex flex-wrap gap-4">
             <RouterLink to="/getting-started" class="cta-button">
-              Try the Loqa alpha
+              Try Loqa Alpha
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L21 10.5m0 0l-3.75 3.75M21 10.5H3" />
               </svg>
             </RouterLink>
             <a href="https://github.com/ambiware-labs/loqa-core" class="cta-button secondary" target="_blank" rel="noopener">
-              View the runtime on GitHub
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5" />
+              </svg>
+              <span>View the runtime on GitHub</span>
             </a>
             <a href="https://github.com/ambiware-labs/loqa-core/blob/main/docs/GETTING_STARTED.md" class="cta-button secondary" target="_blank" rel="noopener">
-              Quickstart guide
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5h7.5m-7.5 0A2.25 2.25 0 006 6.75v10.5A2.25 2.25 0 008.25 19.5h7.5A2.25 2.25 0 0018 17.25V6.75A2.25 2.25 0 0015.75 4.5m-7.5 0V3.75A1.5 1.5 0 019.75 2.25h4.5a1.5 1.5 0 011.5 1.5V4.5" />
+              </svg>
+              <span>Quickstart guide</span>
             </a>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
+    <div id="ambient-intelligence" class="mx-auto max-w-6xl px-6 py-16 md:py-20">
       <h2 class="font-display text-3xl text-white">What is ambient intelligence?</h2>
       <p class="mt-3 max-w-3xl text-white/70">
         Ambient intelligence is technology that blends into your environment and works with you. It stays quiet until it’s helpful,
-        responding to presence, context, and behaviour without exporting your data.
+        responding to presence, context, and behaviour without exporting your data. It frees you from constantly managing devices so you can stay present in your space.
       </p>
       <div class="mt-10 grid gap-6 md:grid-cols-2">
         <div
@@ -189,7 +230,7 @@ const communityLinks = [
       </div>
     </div>
 
-    <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
+    <div id="how-it-works" class="mx-auto max-w-6xl px-6 py-16 md:py-20">
       <h2 class="font-display text-3xl text-white">How Loqa works</h2>
       <p class="mt-3 max-w-3xl text-white/70">
         Sense the world, reason locally, and respond through ambient surfaces. Loqa keeps every hop on your network unless you opt in to extras.
@@ -204,15 +245,32 @@ const communityLinks = [
           <p class="mt-3 text-sm text-white/70">{{ step.description }}</p>
         </div>
       </div>
+      <PipelineDiagram />
     </div>
 
-    <div class="border-t border-white/10 bg-black/30">
+    <div id="open-core" class="border-t border-white/10 bg-black/30">
       <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
         <h2 class="font-display text-3xl text-white">Our hybrid open-core model</h2>
         <p class="mt-3 max-w-3xl text-white/70">
           Loqa blends the best of Blender, Home Assistant, and OBS. The core stays MIT-licensed, extensions thrive in the
-          ecosystem, and optional services keep the lights on without touching your data.
+          ecosystem, and optional services—like Loqa Cloud sync, curated Studio persona packs, and paid support—keep the lights on without touching your data.
         </p>
+        <div class="mt-6 rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-white/70 shadow shadow-black/20">
+          <div class="flex items-start gap-3">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="mt-0.5 h-5 w-5 text-brand-blue">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 01.518-.012c.17.058.32.202.32.415v3.367m0 0H12m0 0h.75M12 17.25h.008v.008H12v-.008z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div>
+              <p class="font-semibold text-white/80">
+                What we mean by “Composable Open Core”
+              </p>
+              <p class="mt-2">
+                The runtime, skill host, and tooling stay MIT-licensed forever—you can self-host, fork, and extend without permission. Sustainability comes from optional Studio add-ons and Loqa Cloud, which plug in as extra modules without gating the core or forcing telemetry.
+              </p>
+            </div>
+          </div>
+        </div>
         <div class="mt-10 grid gap-6 md:grid-cols-3">
           <div
             v-for="pillar in pillars"
@@ -237,10 +295,57 @@ const communityLinks = [
             </a>
           </div>
         </div>
+        <StudioModelDiagram />
+        <StudioFlowDiagram />
+        <div class="mt-8 grid gap-6 md:grid-cols-2">
+          <div class="rounded-2xl border border-white/10 bg-white/10 p-6">
+            <h3 class="font-display text-xl text-white">Why Studio packs feel different</h3>
+            <p class="mt-3 text-sm text-white/70">
+              Studio personas are hand-tuned for locality, culture, and accessibility. Each pack carries:
+            </p>
+            <ul class="mt-4 space-y-2 text-sm text-white/70">
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Distinct voices and behaviours curated by human writers, not scraped from the public web.</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Local dialect and etiquette profiles so Loqa fits into your household or workspace.</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Ethical sourcing, transparent changelogs, and offline evaluation suites to keep trust front and centre.</span>
+              </li>
+            </ul>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/10 p-6">
+            <h3 class="font-display text-xl text-white">What&apos;s inside a pack?</h3>
+            <p class="mt-3 text-sm text-white/70">
+              Each release bundles personas and deterministic skills that can be self-hosted or used with Loqa Cloud.
+            </p>
+            <ul class="mt-4 space-y-2 text-sm text-white/70">
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Persona manifests (intent prompts, guardrails, telemetry stance).</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Tooling recipes: timers, reminders, smart-home bridges tested with the pack.</span>
+              </li>
+              <li class="flex items-start gap-2">
+                <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-brand-blue"></span>
+                <span>Quality bar checklists so contributors can ship their own commercial bundles.</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="mt-8">
+          <StudioPackCard :pack="samplePack" />
+        </div>
       </div>
     </div>
 
-    <div class="border-t border-white/10 bg-black/20">
+    <div id="use-cases" class="border-t border-white/10 bg-black/20">
       <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
         <h2 class="font-display text-3xl text-white">What can Loqa do today?</h2>
         <p class="mt-3 max-w-2xl text-white/70">
@@ -252,17 +357,24 @@ const communityLinks = [
             :key="scenario.title"
             class="rounded-2xl border border-white/5 bg-white/5 p-6 shadow shadow-black/10"
           >
+            <GlyphIcon :name="scenario.icon" class="mb-4" />
             <h3 class="font-display text-xl text-white">{{ scenario.title }}</h3>
             <p class="mt-3 text-sm text-white/70">{{ scenario.description }}</p>
           </div>
         </div>
+        <RouterLink to="/getting-started#workflows" class="cta-button mt-10 inline-flex">
+          Try these workflows
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L21 10.5m0 0l-3.75 3.75M21 10.5H3" />
+          </svg>
+        </RouterLink>
       </div>
     </div>
 
-    <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
+    <div id="why-loqa" class="mx-auto max-w-6xl px-6 py-16 md:py-20">
       <h2 class="font-display text-3xl text-white">Why Loqa?</h2>
       <p class="mt-3 max-w-2xl text-white/70">
-        Loqa is a full-stack reference for ambient systems. It pairs a fast STT → LLM → TTS pipeline with a deterministic skills runtime so you can ship privacy-first assistants on commodity hardware—and grow into a marketplace of skills without giving up control.
+        Loqa is a full-stack reference for ambient systems. It pairs a fast STT → LLM → TTS pipeline with a deterministic skills runtime so you can ship privacy-first assistants on commodity hardware—and grow into a marketplace of skills without giving up control. Privacy is a feature, not a tradeoff.
       </p>
       <div class="mt-10 grid gap-8 md:grid-cols-2">
         <div v-for="feature in features" :key="feature.title" class="rounded-2xl border border-white/5 bg-white/5 px-6 py-8 shadow-lg shadow-black/10">
@@ -272,21 +384,34 @@ const communityLinks = [
       </div>
     </div>
 
-    <div class="border-t border-white/10 bg-black/40">
+    <div id="roadmap" class="border-t border-white/10 bg-black/40">
       <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
         <h2 class="font-display text-3xl text-white">Build the mesh you need</h2>
         <p class="mt-3 max-w-2xl text-white/70">
           Scale horizontally as you add roles: keep STT on the edge, run planners on the most capable node, and let skills deploy as WASM bundles wherever capacity exists.
         </p>
-        <div class="mt-10 grid gap-6 md:grid-cols-2">
-          <div v-for="stage in roadmap" :key="stage.phase" class="rounded-2xl border border-white/5 bg-brand-gradient-soft px-6 py-8">
-            <h3 class="text-sm font-semibold uppercase tracking-[0.35em] text-brand-blue">{{ stage.phase }}</h3>
-            <ul class="mt-4 space-y-3 text-white/70">
-              <li v-for="item in stage.items" :key="item" class="flex items-start gap-3">
-                <span class="mt-1 inline-block h-2 w-2 rounded-full bg-brand-blue"></span>
-                <span class="text-sm">{{ item }}</span>
-              </li>
-            </ul>
+        <MeshDiagram />
+        <div class="mt-12 relative">
+          <div class="absolute left-4 top-0 h-full w-px bg-white/10 md:left-1/2"></div>
+          <div class="space-y-10 md:grid md:grid-cols-2 md:gap-12 md:space-y-0">
+            <div
+              v-for="(stage, idx) in roadmap"
+              :key="stage.phase"
+              class="relative rounded-2xl border border-white/5 bg-brand-gradient-soft px-6 py-8 shadow shadow-black/20 md:px-8"
+            >
+              <span
+                class="absolute -left-4 top-6 flex h-8 w-8 items-center justify-center rounded-full bg-brand-blue text-sm font-semibold text-brand-dark md:-left-6 md:top-1/2 md:-translate-y-1/2"
+              >
+                {{ idx === 0 ? 'T' : 'N' }}
+              </span>
+              <h3 class="text-sm font-semibold uppercase tracking-[0.35em] text-brand-blue">{{ stage.phase }}</h3>
+              <ul class="mt-4 space-y-3 text-white/70">
+                <li v-for="item in stage.items" :key="item" class="flex items-start gap-3">
+                  <span class="mt-1 inline-block h-2 w-2 rounded-full bg-brand-blue"></span>
+                  <span class="text-sm">{{ item }}</span>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -296,8 +421,29 @@ const communityLinks = [
       <div class="rounded-3xl border border-white/10 bg-white/10 p-8 md:p-12">
         <h2 class="font-display text-3xl text-white">Grab the tools, shape the future</h2>
         <p class="mt-3 max-w-2xl text-white/70">
-          Clone the repo, run <code class="rounded bg-white/10 px-2 py-1 text-sm text-brand-blue">make skills</code>, and start publishing events. We&apos;re building Loqa in the open and every issue, RFC, or discussion helps steer the roadmap.
+          Clone the repo, run <code class="rounded bg-white/10 px-2 py-1 text-sm text-brand-blue">make skills</code>, and start publishing events. Check the quickstart for full setup instructions—we&apos;re building Loqa in the open and every issue, RFC, or discussion helps steer the roadmap.
         </p>
+        <div class="mt-6 grid gap-6 md:grid-cols-2">
+          <div class="space-y-4">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-brand-blue/80">Kickstart commands</h3>
+            <CommandSnippet command="git clone https://github.com/ambiware-labs/loqa-core.git" />
+            <CommandSnippet command="cd loqa-core && make skills && make run" />
+          </div>
+          <div class="space-y-4">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-brand-blue/80">Skill manifest sketch</h3>
+            <pre class="rounded-2xl border border-white/10 bg-black/60 p-5 text-sm text-white/80">
+<code>id: skills.timer
+entry: build/timer.wasm
+permissions:
+  nats:
+    - subject: "skill.timer.#"
+mounts:
+  - path: /state
+    access: read-write
+</code>
+            </pre>
+          </div>
+        </div>
         <div class="mt-8 flex flex-wrap gap-4">
           <a href="https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md" class="cta-button secondary" target="_blank" rel="noopener">
             View the MVP backlog
@@ -305,11 +451,14 @@ const communityLinks = [
           <a href="https://github.com/ambiware-labs/loqa-core/discussions" class="cta-button" target="_blank" rel="noopener">
             Join the community
           </a>
+          <a href="https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md" class="cta-button secondary" target="_blank" rel="noopener">
+            Explore Extension Labs
+          </a>
         </div>
       </div>
     </div>
 
-    <div class="border-t border-white/10 bg-black/35">
+    <div id="community" class="border-t border-white/10 bg-black/35">
       <div class="mx-auto max-w-6xl px-6 py-16 md:py-20">
         <h2 class="font-display text-3xl text-white">Roadmap & community</h2>
         <p class="mt-3 max-w-3xl text-white/70">
@@ -324,6 +473,7 @@ const communityLinks = [
             target="_blank"
             rel="noopener"
           >
+            <GlyphIcon :name="card.icon" class="mb-4" />
             <h3 class="font-display text-xl text-white">{{ card.title }}</h3>
             <p class="mt-3 text-sm text-white/70">{{ card.description }}</p>
           </a>
@@ -343,6 +493,9 @@ const communityLinks = [
             rel="noopener"
           >privacy & data principles</a>
           to learn how we keep ambient intelligence ethical.
+        </p>
+        <p class="mt-4 text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+          No tracking • No cloud lock-in • No data sales
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- tighten hero copy and adjust footer so Loqa leads and Ambiware appears as steward
- add Studio flow + sample pack visuals, tooltip for Composable Open Core, and developer snippets
- simplify sticky nav and link quickstart workflows directly for contributors

## Testing
- npm run build
